### PR TITLE
fix: Data too long for column 에러 수정

### DIFF
--- a/src/main/java/com/ttorang/domain/script/model/entity/Script.java
+++ b/src/main/java/com/ttorang/domain/script/model/entity/Script.java
@@ -26,6 +26,8 @@ public class Script extends BaseTimeEntity {
 
     private String word;
 
+    @Lob
+    @Column(columnDefinition = "TEXT")
     private String content;
 
     private String duplicate;


### PR DESCRIPTION
## 💡 **개요**
- Data too long for column 에러 수정
## 📑 **작업 사항**
- script 엔티티의 content 필드를 "TEXT"로 변경
- DB에서 수동으로 alter 명령어로 엔티티 필드 수정
